### PR TITLE
ADD linux support for Intellij and AndroidStudio

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,27 @@
 
 echo "Installing Square code style configs..."
 
-for i in $HOME/Library/Preferences/IntelliJIdea*/codestyles \
-         $HOME/Library/Preferences/IdeaIC*/codestyles \
-         $HOME/Library/Preferences/AndroidStudio*/codestyles
-do
-  cp -frv $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/configs/* $i 2> /dev/null
-done
+if [ "$(uname)" == "Darwin" ]; then
+  # Mac OS X platform
+  for i in $HOME/Library/Preferences/IntelliJIdea*/codestyles \
+           $HOME/Library/Preferences/IdeaIC*/codestyles \
+           $HOME/Library/Preferences/AndroidStudio*/codestyles
+  do
+    cp -frv $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/configs/* $i 2> /dev/null
+  done
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    # Linux platform
+   for i in $HOME/.IntelliJIdea*/config/codestyles \
+            $HOME/.IdeaIC*/config/codestyles \
+            $HOME/.AndroidStudio*/config/codestyles
+  do
+    cp -frv $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/configs/* $i 2> /dev/null
+  done
+elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+    # Windows NT platform
+    echo "This doesn't support windows."
+    echo "But you can apply patch."
+fi
 
 echo "Done."
 echo ""


### PR DESCRIPTION
I have updated `install.sh` script to check OS platform and install `Square` or `SquareAndroid` based on that.  
This is tested in ubuntu 13.04 for linux support.
![linux_support_prayagupd](https://cloud.githubusercontent.com/assets/978095/3211372/806cced4-ef13-11e3-932f-34370ad1cded.png)
.
