### PR TITLE
Add linux support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,10 @@ echo "Installing Square code style configs..."
 
 for i in $HOME/Library/Preferences/IntelliJIdea*/codestyles \
          $HOME/Library/Preferences/IdeaIC*/codestyles \
-         $HOME/Library/Preferences/AndroidStudio*/codestyles
+         $HOME/Library/Preferences/AndroidStudio*/codestyles \
+         $HOME/.IntelliJIdea*/config/codestyles \
+         $HOME/.IdeaIC*/config/codestyles \
+         $HOME/.AndroidStudio*/config/codestyles
 do
   cp -frv $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/configs/* $i 2> /dev/null
 done


### PR DESCRIPTION
I updated the `install.sh` script to include the Linux paths to the IntelliJ / AndroidStudio codestyles.

I omitted the OS platform check as the script will ignore paths that are not available. (Ref #3)
