### PR TITLE
Add space within array initializer braces

### DIFF
--- a/configs/Square.xml
+++ b/configs/Square.xml
@@ -44,6 +44,7 @@
   <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
   <option name="ALIGN_MULTILINE_FOR" value="false" />
   <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+  <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
   <option name="CALL_PARAMETERS_WRAP" value="1" />
   <option name="METHOD_PARAMETERS_WRAP" value="1" />
   <option name="RESOURCE_LIST_WRAP" value="1" />

--- a/configs/SquareAndroid.xml
+++ b/configs/SquareAndroid.xml
@@ -45,6 +45,7 @@
   <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
   <option name="ALIGN_MULTILINE_FOR" value="false" />
   <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+  <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
   <option name="CALL_PARAMETERS_WRAP" value="1" />
   <option name="METHOD_PARAMETERS_WRAP" value="1" />
   <option name="RESOURCE_LIST_WRAP" value="1" />


### PR DESCRIPTION
Give a little breathing room, making `{1, 2, 3}` a little easier to read as `{ 1, 2, 3 }`.