### PR TITLE
Add creating codestyles/ if not exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,14 +3,19 @@
 
 echo "Installing Square code style configs..."
 
-for i in $HOME/Library/Preferences/IntelliJIdea*/codestyles \
-         $HOME/Library/Preferences/IdeaIC*/codestyles \
-         $HOME/Library/Preferences/AndroidStudio*/codestyles \
-         $HOME/.IntelliJIdea*/config/codestyles \
-         $HOME/.IdeaIC*/config/codestyles \
-         $HOME/.AndroidStudio*/config/codestyles
+CONFIGS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/configs"
+
+for i in $HOME/Library/Preferences/IntelliJIdea*  \
+         $HOME/Library/Preferences/IdeaIC*        \
+         $HOME/Library/Preferences/AndroidStudio* \
+         $HOME/.IntelliJIdea*/config              \
+         $HOME/.IdeaIC*/config                    \
+         $HOME/.AndroidStudio*/config
 do
-  cp -frv $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/configs/* $i 2> /dev/null
+  if [ -d $i ]; then
+    mkdir -p $i/codestyles
+    cp -frv "$CONFIGS"/* $i/codestyles
+  fi
 done
 
 echo "Done."


### PR DESCRIPTION
If IDE's directory exist, but codestyles/ not, the script doesn't install styles.
In my opinion it should. To do that it need to create the codestyles/  directory.
