### PR TITLE
Removed the ridiculous chopping down of binary expressions

### DIFF
--- a/configs/SquareAndroid.xml
+++ b/configs/SquareAndroid.xml
@@ -184,7 +184,7 @@
     <option name="EXTENDS_KEYWORD_WRAP" value="1" />
     <option name="THROWS_KEYWORD_WRAP" value="1" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
-    <option name="BINARY_OPERATION_WRAP" value="5" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
     <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
     <option name="TERNARY_OPERATION_WRAP" value="1" />
     <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />


### PR DESCRIPTION
I propose "Wrap if long", as below:
```
int x =
        (3 + 4 + 5 + 6) * (7 + 8 + 9
            + 10) * (11 + 12 + 13
            + 14 + 0xFFFFFFFF);
```
instead of
```
int x = (3 + 4 + 5 + 6) * (7
        + 8
        + 9
        + 10) * (11
        + 12
        + 13
        + 14
        + 0xFFFFFFFF);
```
*(above examples assume that line has max. 37 characters)*