### PR TITLE
Ensure line-break after last attribute.

### DIFF
--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -71,6 +71,11 @@
   <option name="ENUM_CONSTANTS_WRAP" value="1" />
   <AndroidXmlCodeStyleSettings>
     <option name="USE_CUSTOM_SETTINGS" value="true" />
+    <option name="LAYOUT_SETTINGS">
+      <value>
+        <option name="INSERT_LINE_BREAK_AFTER_LAST_ATTRIBUTE" value="true" />
+      </value>
+    </option>
   </AndroidXmlCodeStyleSettings>
   <JavaCodeStyleSettings>
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />


### PR DESCRIPTION
```xml
<FrameLayout
    android:layout_width="match_parent"
    android:layout_height="match_parent"/>
```
becomes
```xml
<FrameLayout
    android:layout_width="match_parent"
    android:layout_height="match_parent"
    />
```
which is much better for diffs and moving attributes up/down.

@edenman 