### PR TITLE
Added XML code style to format android:name tag.

### DIFF
--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -309,6 +309,16 @@
             </match>
           </rule>
         </section>
+         <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*:name</NAME>
+                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+              </AND>
+            </match>
+          </rule>
+        </section>
         <section>
           <rule>
             <match>


### PR DESCRIPTION
Rearranges  the `android:name` tag present in Manifest and AnimatedVectorDrawable files.

Default Formatting:
```
  <target
        android:animation="@animator/test" 
        android:name="test" />
```

Updated:
```
  <target
        android:name="test"
        android:animation="@animator/test" />
```
