### PR TITLE
using double brackets for safety

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ for i in $HOME/Library/Preferences/IntelliJIdea*  \
          $HOME/.IdeaIC*/config                    \
          $HOME/.AndroidStudio*/config
 do
-  if [ -d $i ]; then
+  if [[ -d $i ]]; then
 
     # Install codestyles
     mkdir -p $i/codestyles


### PR DESCRIPTION
Output when running ./install.sh in zsh:

```
Installing Square IntelliJ configs...
/sq/java-code-styles/configs/codestyles/Square.xml -> /Users/jackdanger/Library/Preferences/IntelliJIdea12/codestyles/Square.xml
/sq/java-code-styles/configs/codestyles/SquareAndroid.xml -> /Users/jackdanger/Library/Preferences/IntelliJIdea12/codestyles/SquareAndroid.xml
/sq/java-code-styles/configs/inspection/Square.xml -> /Users/jackdanger/Library/Preferences/IntelliJIdea12/inspection/Square.xml
./install.sh: line 15: [: too many arguments
/sq/java-code-styles/configs/codestyles/Square.xml -> /Users/jackdanger/Library/Preferences/IdeaIC13/codestyles/Square.xml
/sq/java-code-styles/configs/codestyles/SquareAndroid.xml -> /Users/jackdanger/Library/Preferences/IdeaIC13/codestyles/SquareAndroid.xml
/sq/java-code-styles/configs/inspection/Square.xml -> /Users/jackdanger/Library/Preferences/IdeaIC13/inspection/Square.xml
/sq/java-code-styles/configs/codestyles/Square.xml -> /Users/jackdanger/Library/Preferences/IdeaIC15/codestyles/Square.xml
/sq/java-code-styles/configs/codestyles/SquareAndroid.xml -> /Users/jackdanger/Library/Preferences/IdeaIC15/codestyles/SquareAndroid.xml
/sq/java-code-styles/configs/inspection/Square.xml -> /Users/jackdanger/Library/Preferences/IdeaIC15/inspection/Square.xml
Done.

Restart IntelliJ and/or AndroidStudio, go to preferences, and apply 'Square' or 'SquareAndroid'.
```