### PR TITLE
Added support for usernames with spaces.

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -4,9 +4,9 @@ echo Installing Square IntelliJ configs...
 
 setlocal enableDelayedExpansion
 
-for /D %%i in (%userprofile%\.AndroidStudio*) do call :copy_config %%i
-for /D %%i in (%userprofile%\.IdeaIC*) do call :copy_config %%i
-for /D %%i in (%userprofile%\.IntelliJIdea*) do call :copy_config %%i
+for /D %%i in ("%userprofile%"\.AndroidStudio*) do call :copy_config "%%i"
+for /D %%i in ("%userprofile%"\.IdeaIC*) do call :copy_config "%%i"
+for /D %%i in ("%userprofile%"\.IntelliJIdea*) do call :copy_config "%%i"
 
 echo.
 echo Restart IntelliJ and/or AndroidStudio, go to preferences, and apply 'Square' or 'SquareAndroid'.
@@ -15,8 +15,8 @@ exit /b
 REM sub function for copy config files
 :copy_config
 set config_dir=%~1\config
-echo Installing to !config_dir!
-xcopy /s configs !config_dir!
+echo Installing to "!config_dir!"
+xcopy /s configs "!config_dir!"
 echo Done.
 echo.
 exit /b


### PR DESCRIPTION
If a Windows user has a space character in the username,

1. `userprofile` breaks into 2 variables and must be saved with `" "`.
2. `call :copy_config` is supplied with an argument but if there is a space in the argument value, it breaks into 2 arguments.
3. command `xcopy /s configs C:\Users\John Doe` is also supplied with 2 arguments because of the space character.