### PR TITLE
Do not use star imports

### DIFF
--- a/configs/codestyles/Square.xml
+++ b/configs/codestyles/Square.xml
@@ -74,6 +74,8 @@
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">
       <value />
     </option>
+    <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+    <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
   </JetCodeStyleSettings>
   <SqlCodeStyleSettings>
     <option name="ALIGN_AS_IN_SELECT_STATEMENT" value="false" />


### PR DESCRIPTION
Kotlin appears to have the default option of using star imports after N
imports of the same package. Turn that off.