### PR TITLE
Use a continuation indent for parameter declarations.

### DIFF
--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -102,8 +102,6 @@
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="999" />
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="999" />
     <option name="IMPORT_NESTED_CLASSES" value="true" />
-    <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
-    <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="false" />
     <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     <option name="IF_RPAREN_ON_NEW_LINE" value="true" />
   </JetCodeStyleSettings>
@@ -246,7 +244,6 @@
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-    <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
     <option name="METHOD_PARAMETERS_WRAP" value="2" />
     <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
     <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />


### PR DESCRIPTION
The Android guide recommends a continuation indent for these (8 spaces in that case;
4 spaces in ours).

https://android.github.io/kotlin-guides/style.html#functions