### PR TITLE
Don't force align Groovy list and map literals

### DIFF
--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -72,6 +72,10 @@
       </value>
     </option>
   </AndroidXmlCodeStyleSettings>
+  <GroovyCodeStyleSettings>
+    <option name="ALIGN_MULTILINE_LIST_OR_MAP" value="false" />
+    <option name="ALIGN_NAMED_ARGS_IN_MAP" value="false" />
+  </GroovyCodeStyleSettings>
   <JavaCodeStyleSettings>
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />


### PR DESCRIPTION
Analog to this setting:
![screen shot 2018-03-28 at 2 16 21 pm](https://user-images.githubusercontent.com/1868149/38048743-3470461e-3294-11e8-9ae9-8d0fec37d342.png)

Before:
![screen shot 2018-03-28 at 2 24 11 pm](https://user-images.githubusercontent.com/1868149/38048750-397c5a08-3294-11e8-8ae1-78e0a43cdf25.png)

After:
![screen shot 2018-03-28 at 2 23 52 pm](https://user-images.githubusercontent.com/1868149/38048726-27b21c9a-3294-11e8-826a-a29ab6b1e0f9.png)
