### PR TITLE
Improves the default alignment for multiline booleans with parentheses

### DIFF
--- a/configs/codestyles/Square.xml
+++ b/configs/codestyles/Square.xml
@@ -167,6 +167,7 @@
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="ALIGN_MULTILINE_PARENTHESIZED_EXPRESSION" value="true" />
     <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />


### PR DESCRIPTION
The option's not perfect, and often results in too much indentation (indent multiline parenthesized expressions would be better), but it's a lot better than having &&'s and ||'s at the same alignment regardless of parens.