### PR TITLE
Reduce Kotlin continuation indent to 2 spaces

### DIFF
--- a/configs/codestyles/Square.xml
+++ b/configs/codestyles/Square.xml
@@ -310,7 +310,7 @@
     <option name="ENUM_CONSTANTS_WRAP" value="2" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
       <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>

--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -256,7 +256,7 @@
     <option name="ENUM_CONSTANTS_WRAP" value="2" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
       <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>


### PR DESCRIPTION
Keeps it consistent with the other indent settings