### PR TITLE
Revert "app:layout_* should sort above app:* in XML attributes"

### DIFF
--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -386,17 +386,6 @@
         <section>
           <rule>
             <match>
-              <AND>
-                <NAME>app:layout_.*</NAME>
-                <XML_NAMESPACE>http://schemas.android.com/apk/res-auto</XML_NAMESPACE>
-              </AND>
-            </match>
-            <order>BY_NAME</order>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
               <NAME>.*(?&lt;!style)$</NAME>
             </match>
             <order>BY_NAME</order>


### PR DESCRIPTION
Reverts square/java-code-styles#64