### PR TITLE
IntelliJ 2020.1 support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,23 +8,23 @@ CONFIGS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/configs"
 for i in $HOME/Library/Preferences/IntelliJIdea*  \
          $HOME/Library/Preferences/IdeaIC*        \
          $HOME/Library/Preferences/AndroidStudio* \
+         $HOME/Library/Application\ Support/JetBrains/IntelliJIdea* \
          $HOME/.IntelliJIdea*/config              \
          $HOME/.IdeaIC*/config                    \
          $HOME/.AndroidStudio*/config
 do
-  if [[ -d $i ]]; then
-
+  if [[ -d "$i" ]]; then
     # Install codestyles
-    mkdir -p $i/codestyles
-    cp -frv "$CONFIGS/codestyles"/* $i/codestyles
+    mkdir -p "$i/codestyles"
+    cp -frv "$CONFIGS/codestyles"/* "$i/codestyles"
 
     # Install inspections
-    mkdir -p $i/inspection
-    cp -frv "$CONFIGS/inspection"/* $i/inspection
+    mkdir -p "$i/inspection"
+    cp -frv "$CONFIGS/inspection"/* "$i/inspection"
 
     # Install options ("Exclude from Import and Completion")
-    mkdir -p $i/options
-    cp -frv "$CONFIGS/options"/* $i/options
+    mkdir -p "$i/options"
+    cp -frv "$CONFIGS/options"/* "$i/options"
   fi
 done
 


### PR DESCRIPTION
The same config files work for IntelliJ 2020.1, but the location has changed
so added that directory. Also quoting the variable derefences since the new
path contains a space and it doesn't work without it