### PR TITLE
Concise inner class imports

### DIFF
--- a/configs/codestyles/Square.xml
+++ b/configs/codestyles/Square.xml
@@ -69,6 +69,7 @@
   <option name="ENUM_CONSTANTS_WRAP" value="1" />
   <JavaCodeStyleSettings>
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
+    <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
   </JavaCodeStyleSettings>
   <JetCodeStyleSettings>
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">

--- a/configs/codestyles/Square.xml
+++ b/configs/codestyles/Square.xml
@@ -70,6 +70,9 @@
   <JavaCodeStyleSettings>
     <option name="CLASS_NAMES_IN_JAVADOC" value="3" />
     <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+    <DO_NOT_IMPORT_INNER>
+      <CLASS name="Builder" />
+    </DO_NOT_IMPORT_INNER>
   </JavaCodeStyleSettings>
   <JetCodeStyleSettings>
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">


### PR DESCRIPTION
_(I haven't used IntelliJ for that long and am far from an expert; apologies in advance if I'm missing something obvious or any part of this doesn't make sense!)_

Hi, just wanted to suggest adding the `INSERT_INNER_CLASS_IMPORTS` option here. This maps to the "Insert imports for inner classes" checkbox IntelliJ setting in Editor > Code Style > Java > Imports tab.

With this enabled, and assuming a class like this:
```
public class Foo {
  public static class Bar {
  }
}
```

You can write `Ba` and press ⌥+Space to autocomplete and auto-import `Bar`.

With the flag disabled, you'll end up with `Foo.Bar`. That outer class qualifier can reduce ambiguity, but I'd argue that the majority of the time, you won't need to refer to multiple `Bar` types within a single file. When you do need this, it's simple to achieve the desired `Foo.Bar` outcome by autocompleting both fragments (e.g. type `Fo` -> ⌥+Space to import `Foo` -> type `.Ba` -> ⌥+Space to import `Bar`), or by writing `Foo.Ba` and autocompleting only the inner class if `Foo` is already imported.

On the other hand, with this option disabled, there's no equally-simple way (at least as far as I've found) to automatically perform the static import and enable unqualified references to `Bar`. It can be done with another ⌥+Space keypress to select "Add Import for...", but that's a second step that has to be done once per imported inner class per file. So, since *enabling* this option makes it easy to write code in both styles (either referring to `OuterClass.InnerClass` or to the unqualified `InnerClass` directly), while *disabling* this option makes the latter option difficult, I think enabling this option is a better default.