### PR TITLE
Stop always wrapping chained function calls in Kotlin. 

### DIFF
--- a/configs/codestyles/Square.xml
+++ b/configs/codestyles/Square.xml
@@ -303,7 +303,7 @@
     <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
     <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
     <option name="EXTENDS_LIST_WRAP" value="5" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
     <option name="ASSIGNMENT_WRAP" value="1" />
     <option name="METHOD_ANNOTATION_WRAP" value="1" />
     <option name="FIELD_ANNOTATION_WRAP" value="1" />

--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -249,7 +249,7 @@
     <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
     <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
     <option name="EXTENDS_LIST_WRAP" value="5" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
     <option name="ASSIGNMENT_WRAP" value="1" />
     <option name="METHOD_ANNOTATION_WRAP" value="1" />
     <option name="FIELD_ANNOTATION_WRAP" value="1" />


### PR DESCRIPTION
The old setting used "Always wrap", the new setting uses "Chop down if long". The Java code style uses "Chop down if long", too.

The old setting made code harder to read in many scenarios:

```kotlin
// Old
assertThat(myList).containsExactly("a", "b", "c")
    .inOrder()

// New
assertThat(myList).containsExactly("a", "b", "c").inOrder()
```

```kotlin
// Old
if (project.file("src/debug")
        .exists() || project.file("src/release")
        .exists()
) {
  return
}

// New
if (project.file("src/debug").exists() || project.file("src/release").exists()) {
  return
}
```

```kotlin
// Old
val string = "The project path is ${
      project.path.substring(1)
          .replace(':', '/')
    }"

// New
val string = "The project path is ${project.path.substring(1).replace(':', '/')}"
```

```kotlin
// Old
stringList
    .filter {..}
    .map {
      it.trim()
          .substring(1)
    }

// New
stringList
    .filter {..}
    .map { it.trim().substring(1) }
```