### PR TITLE
Update the install path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,9 @@ for i in $HOME/Library/Preferences/IntelliJIdea*  \
          $HOME/Library/Application\ Support/JetBrains/IntelliJIdea* \
          $HOME/.IntelliJIdea*/config              \
          $HOME/.IdeaIC*/config                    \
-         $HOME/.AndroidStudio*/config
+         $HOME/.AndroidStudio*/config \
+         $HOME/Library/Application\ Support/Google/AndroidStudio* \
+         $HOME/Library/Application\ Support/JetBrains/IdeaIC*
 do
   if [[ -d "$i" ]]; then
     # Install codestyles


### PR DESCRIPTION
Update the install path for newer IntelliJ and Android Studio versions when using the JetBrains Toolbox.

This is similar to #76, but also includes IntelliJ.