### PR TITLE
exclude wrong Inject types

### DIFF
--- a/configs/options/editor.codeinsight.xml
+++ b/configs/options/editor.codeinsight.xml
@@ -3,7 +3,9 @@
     <EXCLUDED_PACKAGE NAME="autovalue.shaded" />
     <EXCLUDED_PACKAGE NAME="avro.shaded" />
     <EXCLUDED_PACKAGE NAME="com.beust.jcommander.internal" />
+    <EXCLUDED_PACKAGE NAME="com.google.inject.Inject" />
     <EXCLUDED_PACKAGE NAME="com.sun.istack" />
+    <EXCLUDED_PACKAGE NAME="com.sun.jersey.spi.inject.Inject" />
     <EXCLUDED_PACKAGE NAME="jline.internal" />
     <EXCLUDED_PACKAGE NAME="joptsimple.internal" />
     <EXCLUDED_PACKAGE NAME="junit.framework.Assert" />
@@ -12,6 +14,5 @@
     <EXCLUDED_PACKAGE NAME="org.hibernate.validator.internal" />
     <EXCLUDED_PACKAGE NAME="org.mockito.internal.util.collections" />
     <EXCLUDED_PACKAGE NAME="org.mockito.internal.verification.VerificationModeFactory" />
-    <EXCLUDED_PACKAGE NAME="junit.framework.Assert" />
   </component>
 </application>


### PR DESCRIPTION
According to the Square Java style guide, we should prefer `javax.inject.Inject` for dependency injection: https://wiki.sqprod.co/pages/viewpage.action?pageId=14811784

This PR excludes the other two Inject options from IJ suggestions, enabling developers to auto-import the desired type after annotating a field or constructor with `@Inject`. The google one, at least, still seems to work fine, but there's no reason to prefer it, so we should stick with the style guide's recommendation and also eliminate the manual touchpoint of choosing an import from a list.

Another nice benefit of using the javax type is that IJ understands it, so it prevents the annoying "managed bean must have a constructor with no parameters, or a constructor annotated @Inject" error.

The `com.google.inject.Inject` type is already in widespread use (5k results searching for the import on `go/grep`, vs. 10k for the javax type), but this change shouldn't create a nuisance for anyone working in one of those files - it will just affect import suggestions.

Also - `junit.framework.Assert` was in here twice; I removed the duplicate.