### PR TITLE
Add `UseExpressionBody` as WARNING

### DIFF
--- a/configs/inspection/SquareAndroid.xml
+++ b/configs/inspection/SquareAndroid.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inspections version="1.0" is_locked="false">
+  <option name="myName" value="SquareAndroid" />
+    <inspection_tool class="UseExpressionBody" enabled="true" level="WARNING" enabled_by_default="true" />
+</inspections>
+


### PR DESCRIPTION
Add the Kotlin `UseExpressionBody` inspection as a warning
since it is part of the Square style guide.

![image](https://user-images.githubusercontent.com/1205783/106088065-19633080-60da-11eb-87b3-b1ca87c82614.png)

Becomes

![image](https://user-images.githubusercontent.com/1205783/106088095-25e78900-60da-11eb-828e-2259faeaa885.png)