### PR TITLE
add SUGGEST_NULLABLE_ANNOTATIONS inspection

### DIFF
--- a/configs/inspection/Square.xml
+++ b/configs/inspection/Square.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inspections version="1.0" is_locked="false">
   <option name="myName" value="Square" />
+  <inspection_tool class="ConstantConditions" enabled="true" level="WARNING" enabled_by_default="true">
+    <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="true" />
+  </inspection_tool>
   <inspection_tool class="FallthruInSwitchStatement" enabled="true" level="ERROR" enabled_by_default="true" />
   <inspection_tool class="UnnecessarySemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
 </inspections>


### PR DESCRIPTION
add ConstantConditions.SUGGEST_NULLABLE_ANNOTATIONS to inspections.

This inspection flags code that mixes @Nullable values and non-@Nullable params.

By Square Java convention, we treat unannotated method params as non-null by default.
Thus, code that mixes nullability in this way is likely incorrect, and creates an easy place for NPEs to hide.

With this change, a method call that passes a value IntelliJ determines to be possibly null into a method parameter not annotated as @Nullable will be highlighted with the warning text, `Argument '<some possibly-null expression>' might be null but passed to non-annotated parameter`.