### PR TITLE
Fix trailing commas configuration - KTIJ-22516.

### DIFF
--- a/configs/codestyles/Square.xml
+++ b/configs/codestyles/Square.xml
@@ -77,6 +77,8 @@
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
     <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="false" />
+    <!-- TODO: remove in favor of `codeStyleSettings` once this is fixed: https://youtrack.jetbrains.com/issue/KTIJ-22516. -->
+    <option name="ALLOW_TRAILING_COMMA" value="true" />
   </JetCodeStyleSettings>
   <SqlCodeStyleSettings>
     <option name="ALIGN_AS_IN_SELECT_STATEMENT" value="false" />

--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -109,6 +109,8 @@
     <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="false" />
     <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
     <option name="IF_RPAREN_ON_NEW_LINE" value="true" />
+    <!-- TODO: remove in favor of `codeStyleSettings` once this is fixed: https://youtrack.jetbrains.com/issue/KTIJ-22516. -->
+    <option name="ALLOW_TRAILING_COMMA" value="true" />
   </JetCodeStyleSettings>
   <XML>
     <option name="XML_ALIGN_ATTRIBUTES" value="false" />


### PR DESCRIPTION
`ALLOW_TRAILING_COMMA` configuration does not currently get picked up by
IJ/AS, it only works if it's set up using legacy `JetCodeStyleSettings`
block. See https://youtrack.jetbrains.com/issue/KTIJ-22516 for more
details, enabling trailing commas via `JetCodeStyleSettings` until the
IDE bug is fixed.
