### PR TITLE
Warn about ignored tests

### DIFF
--- a/configs/inspection/Square.xml
+++ b/configs/inspection/Square.xml
@@ -43,4 +43,5 @@
       </list>
     </option>
   </inspection_tool>
+  <inspection_tool class="IgnoredJUnitTest" enabled="true" level="WARNING" enabled_by_default="true" />
 </profile>


### PR DESCRIPTION
Flaky tests are a common problem at Block.  To combat the flakiness we oftentimes automate ignoring tests.  This warning will make those ignored tests more visible and hopefully inspire developers to fix the underlying flakiness issues and re-enable tests.