### PR TITLE
Explicit Kotlin import layout

### DIFF
--- a/configs/codestyles/SquareAndroid.xml
+++ b/configs/codestyles/SquareAndroid.xml
@@ -99,6 +99,11 @@
     <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
   </JavaCodeStyleSettings>
   <JetCodeStyleSettings>
+    <option name="PACKAGES_IMPORT_LAYOUT">
+      <value>
+        <package name="" alias="false" withSubpackages="true" />
+      </value>
+    </option>
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">
       <value />
     </option>


### PR DESCRIPTION
Specify an explicit import layout instead of relying on the Kotlin Official default. The Kotlin Official style uses `ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^`. There isn't a reason why these packages should be treated differently. The new explicit import layout changes it to `ij_kotlin_imports_layout = *`, which is for example used by ktfmt, too.